### PR TITLE
Fixed async binding in IValueProvider adding support to WebJobs SDK 2.0.

### DIFF
--- a/WebJobs.ApplicationInsightsTracer/Bindings/AITracerValueProvider.cs
+++ b/WebJobs.ApplicationInsightsTracer/Bindings/AITracerValueProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace WebJobs.ApplicationInsightsTracer.Bindings
 {
     using System;
+    using System.Threading.Tasks;
     using Microsoft.Azure.WebJobs.Host.Bindings;
     using Tracing;
 
@@ -18,6 +19,11 @@
         public object GetValue()
         {
             return _aiWebjobTracer;
+        }
+
+        public Task<object> GetValueAsync()
+        {
+            return Task.FromResult(GetValue());
         }
 
         public string ToInvokeString()


### PR DESCRIPTION
In the version 2.0 of Microsoft.Azure.WebJobs, the IValueProvider has changed, removing GetValue() and changing it with GetValueAsync().

I've added GetValueAsync to the implementation keeping GetValue as well. Keeping both methods lets the tracer work with 1.X and 2.X.